### PR TITLE
Disable 'loadbalancer' command

### DIFF
--- a/cmd/loadbalancer.go
+++ b/cmd/loadbalancer.go
@@ -20,7 +20,7 @@ var loadBalancerCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(loadBalancerCmd)
+	// rootCmd.AddCommand(loadBalancerCmd)
 	loadBalancerCmd.AddCommand(loadBalancerListCmd)
 	loadBalancerCmd.AddCommand(loadBalancerRemoveCmd)
 	loadBalancerCmd.AddCommand(loadBalancerCreateCmd)


### PR DESCRIPTION
Because the Load Balancer feature in [CivoStack](https://www.civo.com/blog/new-year-new-york-new-civostack) is still in development, I'm disabling this command.

It was built for Civo's previous stack (OpenStack). Since OpenStack has reached EOL and the Civo API is no longer working for OpenStack, there is no point to keep this command. Once Load Balancer for CivoStack is ready (both from infra and API sides), we will enable this command again.

---

Close #156 