### PR TITLE
Allow shorter node pool ids for scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ The pool (8064c7) was added to the cluster (my-first-cluster)
 
 #### Scaling pools in the cluster
 
-You can scale a pool in your cluster, while the cluster is running. It takes the name of the cluster (or the ID), the pool ID (min. 6 characters), and `--nodes` which is the new number of nodes in the pool. You can get the pool ID details form `civo k3s show my-first-cluster`
+You can scale a pool in your cluster, while the cluster is running. It takes the name of the cluster (or the ID), the pool ID (at least 6 characters), and `--nodes` which is the new number of nodes in the pool. You can get the pool ID details form `civo k3s show my-first-cluster`
 
 ```sh
 civo kubernetes node-pool scale my-first-cluster pool-id --nodes 5
@@ -598,7 +598,7 @@ civo kubernetes node-pool scale my-first-cluster pool-id --nodes 5
 
 #### Deleting pools in the cluster
 
-You can delete a pool in your cluster. It takes the name of the cluster (or the ID) and the pool ID (min. 6 characters)
+You can delete a pool in your cluster. It takes the name of the cluster (or the ID) and the pool ID (at least 6 characters)
 
 ```sh
 civo kubernetes node-pool delete my-first-cluster pool-id

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ The pool (8064c7) was added to the cluster (my-first-cluster)
 
 #### Scaling pools in the cluster
 
-You can scale a pool in your cluster, while the cluster is running. It takes the name of the cluster (or the ID), the pool ID, and `--nodes` which is the new number of nodes in the pool. You can get the pool ID details form `civo k3s show my-first-cluster`
+You can scale a pool in your cluster, while the cluster is running. It takes the name of the cluster (or the ID), the pool ID (min. 6 characters), and `--nodes` which is the new number of nodes in the pool. You can get the pool ID details form `civo k3s show my-first-cluster`
 
 ```sh
 civo kubernetes node-pool scale my-first-cluster pool-id --nodes 5
@@ -598,7 +598,7 @@ civo kubernetes node-pool scale my-first-cluster pool-id --nodes 5
 
 #### Deleting pools in the cluster
 
-You can delete a pool in your cluster. It takes the name of the cluster (or the ID) and the pool ID
+You can delete a pool in your cluster. It takes the name of the cluster (or the ID) and the pool ID (min. 6 characters)
 
 ```sh
 civo kubernetes node-pool delete my-first-cluster pool-id

--- a/cmd/kubernetes_nodepool_create.go
+++ b/cmd/kubernetes_nodepool_create.go
@@ -70,7 +70,7 @@ var kubernetesNodePoolCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(outputFields)
 		default:
-			fmt.Printf("The pool (%s) was added to the cluster (%s)\n", utility.Green(poolID[:6]), utility.Green(kubernetesCluster.Name))
+			fmt.Printf("The pool (%s) was added to the cluster (%s)\n", utility.Green(poolID), utility.Green(kubernetesCluster.Name))
 		}
 	},
 }

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -48,7 +48,7 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 		kubernetesPoolNameList := []string{}
 		for _, v := range kuberneteNodePoolList {
 			if len(v.Name) < 6 {
-				utility.Error("Please provide the node pool ID with atleast 6 characters for %s", v.Name)
+				utility.Error("Please provide the node pool ID with at least 6 characters for %s", v.Name)
 				os.Exit(1)
 			}
 			kubernetesPoolNameList = append(kubernetesPoolNameList, v.Name)

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -47,6 +47,10 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 
 		kubernetesPoolNameList := []string{}
 		for _, v := range kubernetesNodePoolList {
+			if len(v.Name) < 6 {
+				utility.Error("Please provide the node pool ID with atleast 6 characters for %s", v.Name)
+				os.Exit(1)
+			}
 			kubernetesPoolNameList = append(kubernetesPoolNameList, v.Name)
 		}
 

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -47,6 +47,10 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 
 		kubernetesPoolNameList := []string{}
 		for _, v := range kuberneteNodePoolList {
+			if len(v.Name) < 6 {
+				utility.Error("Please provide the node pool ID with atleast 6 characters for %s", v.Name)
+				os.Exit(1)
+			}
 			kubernetesPoolNameList = append(kubernetesPoolNameList, v.Name)
 		}
 

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -67,8 +67,9 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 				nodePool = append(nodePool, civogo.KubernetesClusterPoolConfig{ID: v.ID, Count: v.Count, Size: v.Size})
 			}
 
+			kubernetesPoolNameList = nil
 			for _, kubeList := range kuberneteNodePoolList {
-				nodePool = utility.RemoveNodePool(nodePool, kubeList.Name)
+				nodePool, kubernetesPoolNameList = utility.RemoveNodePool(nodePool, kubeList.Name, kubernetesPoolNameList)
 			}
 
 			configKubernetes := &civogo.KubernetesClusterConfig{

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -48,7 +48,7 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 		kubernetesPoolNameList := []string{}
 		for _, v := range kubernetesNodePoolList {
 			if len(v.Name) < 6 {
-				utility.Error("Please provide the node pool ID with atleast 6 characters for %s", v.Name)
+				utility.Error("Please provide the node pool ID with at least 6 characters for %s", v.Name)
 				os.Exit(1)
 			}
 			kubernetesPoolNameList = append(kubernetesPoolNameList, v.Name)

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var kuberneteNodePoolList []utility.ObjecteList
+var kubernetesNodePoolList []utility.ObjecteList
 var kubernetesNodePoolDeleteCmd = &cobra.Command{
 	Use:     "delete",
 	Aliases: []string{"delete", "rm"},
@@ -38,19 +38,19 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 		}
 
 		if len(args) == 1 {
-			kuberneteNodePoolList = append(kuberneteNodePoolList, utility.ObjecteList{ID: args[0], Name: args[1]})
+			kubernetesNodePoolList = append(kubernetesNodePoolList, utility.ObjecteList{ID: args[0], Name: args[1]})
 		} else {
 			for _, v := range args[1:] {
-				kuberneteNodePoolList = append(kuberneteNodePoolList, utility.ObjecteList{ID: args[0], Name: v})
+				kubernetesNodePoolList = append(kubernetesNodePoolList, utility.ObjecteList{ID: args[0], Name: v})
 			}
 		}
 
 		kubernetesPoolNameList := []string{}
-		for _, v := range kuberneteNodePoolList {
+		for _, v := range kubernetesNodePoolList {
 			kubernetesPoolNameList = append(kubernetesPoolNameList, v.Name)
 		}
 
-		if utility.UserConfirmedDeletion(fmt.Sprintf("node %s", pluralize.Pluralize(len(kuberneteNodePoolList), "pool")), defaultYes, strings.Join(kubernetesPoolNameList, ", ")) {
+		if utility.UserConfirmedDeletion(fmt.Sprintf("node %s", pluralize.Pluralize(len(kubernetesNodePoolList), "pool")), defaultYes, strings.Join(kubernetesPoolNameList, ", ")) {
 
 			nodePool := []civogo.KubernetesClusterPoolConfig{}
 			kubernetesFindCluster, err := client.FindKubernetesCluster(args[0])
@@ -63,7 +63,7 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 				nodePool = append(nodePool, civogo.KubernetesClusterPoolConfig{ID: v.ID, Count: v.Count, Size: v.Size})
 			}
 
-			for _, kubeList := range kuberneteNodePoolList {
+			for _, kubeList := range kubernetesNodePoolList {
 				nodePool = utility.RemoveNodePool(nodePool, kubeList.Name)
 			}
 
@@ -79,14 +79,14 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 
 			ow := utility.NewOutputWriter()
 
-			for _, v := range kuberneteNodePoolList {
+			for _, v := range kubernetesNodePoolList {
 				ow.StartLine()
 				ow.AppendDataWithLabel("id", v.Name, "ID")
 			}
 
 			switch outputFormat {
 			case "json":
-				if len(kuberneteNodePoolList) == 1 {
+				if len(kubernetesNodePoolList) == 1 {
 					ow.WriteSingleObjectJSON(prettySet)
 				} else {
 					ow.WriteMultipleObjectsJSON(prettySet)
@@ -94,7 +94,7 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(outputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted from the cluster (%s)\n", fmt.Sprintf("node %s", pluralize.Pluralize(len(kuberneteNodePoolList), "pool")), utility.Green(strings.Join(kubernetesPoolNameList, ", ")), utility.Green(kubernetesCluster.Name))
+				fmt.Printf("The %s (%s) has been deleted from the cluster (%s)\n", fmt.Sprintf("node %s", pluralize.Pluralize(len(kubernetesNodePoolList), "pool")), utility.Green(strings.Join(kubernetesPoolNameList, ", ")), utility.Green(kubernetesCluster.Name))
 			}
 		} else {
 			fmt.Println("Operation aborted.")

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -67,8 +67,9 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 				nodePool = append(nodePool, civogo.KubernetesClusterPoolConfig{ID: v.ID, Count: v.Count, Size: v.Size})
 			}
 
+			kubernetesPoolNameList = nil
 			for _, kubeList := range kubernetesNodePoolList {
-				nodePool = utility.RemoveNodePool(nodePool, kubeList.Name)
+				nodePool, kubernetesPoolNameList = utility.RemoveNodePool(nodePool, kubeList.Name, kubernetesPoolNameList)
 			}
 
 			configKubernetes := &civogo.KubernetesClusterConfig{

--- a/cmd/kubernetes_nodepool_scale.go
+++ b/cmd/kubernetes_nodepool_scale.go
@@ -28,7 +28,7 @@ var kubernetesNodePoolScaleCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		nodePoolID := args[1]
 		if len(nodePoolID) < 6 {
-			utility.Error("Please provide the node pool ID with atleast 6 characters for %s", nodePoolID)
+			utility.Error("Please provide the node pool ID with at least 6 characters for %s", nodePoolID)
 			os.Exit(1)
 		}
 

--- a/cmd/kubernetes_nodepool_scale.go
+++ b/cmd/kubernetes_nodepool_scale.go
@@ -52,6 +52,7 @@ var kubernetesNodePoolScaleCmd = &cobra.Command{
 		nodePoolFound := false
 		for _, pool := range kubernetesFindCluster.Pools {
 			if strings.Contains(pool.ID, nodePoolID) {
+				nodePoolID = pool.ID
 				nodePoolFound = true
 			}
 		}

--- a/cmd/kubernetes_nodepool_scale.go
+++ b/cmd/kubernetes_nodepool_scale.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/civo/civogo"
 	"github.com/civo/cli/config"
@@ -25,6 +26,12 @@ var kubernetesNodePoolScaleCmd = &cobra.Command{
 		return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		nodePoolID := args[1]
+		if len(nodePoolID) < 6 {
+			utility.Error("Please provide the node pool ID with atleast 6 characters for %s", nodePoolID)
+			os.Exit(1)
+		}
+
 		utility.EnsureCurrentRegion()
 
 		client, err := config.CivoAPIClient()
@@ -42,10 +49,9 @@ var kubernetesNodePoolScaleCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		nodePoolID := args[1]
 		nodePoolFound := false
 		for _, pool := range kubernetesFindCluster.Pools {
-			if pool.ID == nodePoolID {
+			if strings.Contains(pool.ID, nodePoolID) {
 				nodePoolFound = true
 			}
 		}

--- a/utility/kubernetes.go
+++ b/utility/kubernetes.go
@@ -234,17 +234,18 @@ func checkKubeDir() {
 }
 
 // RemoveNodePool is a utility function to remove node pool from a kuberentes cluster
-func RemoveNodePool(s []civogo.KubernetesClusterPoolConfig, id string) []civogo.KubernetesClusterPoolConfig {
+func RemoveNodePool(s []civogo.KubernetesClusterPoolConfig, id string, names []string) ([]civogo.KubernetesClusterPoolConfig, []string) {
 	key := 0
 	for k, v := range s {
 		if strings.Contains(v.ID, id) {
 			key = k
+			names = append(names, v.ID)
 			break
 		}
 	}
 
 	s[len(s)-1], s[key] = s[key], s[len(s)-1]
-	return s[:len(s)-1]
+	return s[:len(s)-1], names
 }
 
 // UpdateNodePool is a utility function to update node pool from a kuberentes cluster


### PR DESCRIPTION
Fixes #158 

Changes - 
- [x] When deleting nodepool, keep strings.Contains usage. Check the length to be at least 6 characters
- [x] When scaling nodepool, implement strings.Contains and check the length to be at least 6 characters
- [x] When user provides short nodepool ID (<6), exit the CLI and ask user to provide an ID with at least 6 characters
- [x] Print full node pool ID after create, scale and delete operations on the node pool