### PR TITLE
Send progress output to stderr instead of stdout

### DIFF
--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -112,7 +112,7 @@ var objectStoreCreateCmd = &cobra.Command{
 		if waitOS {
 			startTime := utility.StartTime()
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 			s.Prefix = fmt.Sprintf("Creating an Object Store with maxSize %d, called %s... ", store.MaxSize, store.Name)
 			s.Start()
 


### PR DESCRIPTION
**Pull Request Description**

Fix for Issue #388: **Spinner Output Cleanup**

This pull request addresses the issue described in [GitHub issue #388](https://github.com/civo/cli/issues/388), where the spinner output was generating unprintable characters.

**Changes Made**:

    Initialized the spinner with a default stderr writer.
    Redirected all spinner output to stderr, ensuring that it does not interfere with standard output.
    This adjustment prevents any unprintable characters from appearing in the final output, enhancing the overall user experience when using the CLI.
    
**Before Change** - 
![WhatsApp Image 2024-10-16 at 8 15 05 AM](https://github.com/user-attachments/assets/36f80278-c726-41e1-b6cf-70d1028ca36c)

**After Change** - 
<img width="879" alt="Screenshot 2024-10-16 at 8 24 13 AM" src="https://github.com/user-attachments/assets/9ca18d50-fb4b-424c-a6a1-f0b5fb16965f">

**Impact**:
This change improves the clarity and usability of the Civo CLI by ensuring that output for this particular command (with -wait flag) is formatted correctly in every case. 