### PR TITLE
chore: add warning for deprecated DB versions

### DIFF
--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -3,12 +3,36 @@ package database
 
 import (
 	"errors"
+	"strings"
 
+	"github.com/civo/civogo"
+	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
 )
 
 var firewallID, networkID, size, updatedName, software, softwareVersion string
 var nodes int
+
+// showDatabaseDeprecationWarning displays a warning message if the database version is deprecated
+func showDatabaseDeprecationWarnings(databases ...civogo.Database) {
+	// We want to show one warning per version at max.
+	pgWarning := false
+	mysqlWarning := false
+
+	for _, db := range databases {
+		software := strings.ToLower(db.Software)
+
+		if software == "mysql" && !mysqlWarning {
+			utility.Warning("MySQL databases are deprecated and will be removed in a future release. Please consider migrating to PostgreSQL.")
+			mysqlWarning = true
+		}
+
+		if software == "postgresql" && strings.HasPrefix(db.SoftwareVersion, "14") && !pgWarning {
+			utility.Warning("PostgreSQL 14 is deprecated and will be removed in a future release. Please consider upgrading to a newer version.")
+			pgWarning = true
+		}
+	}
+}
 
 // DBCmd is the root command for the db subcommand
 var DBCmd = &cobra.Command{

--- a/cmd/database/database_list.go
+++ b/cmd/database/database_list.go
@@ -37,6 +37,8 @@ var dbListCmd = &cobra.Command{
 		}
 
 		ow := utility.NewOutputWriter()
+
+		// Track if we've shown any deprecation warnings
 		for _, db := range databases.Items {
 			ports := []string{}
 			for _, user := range db.DatabaseUserInfo {
@@ -63,5 +65,10 @@ var dbListCmd = &cobra.Command{
 		}
 
 		ow.FinishAndPrintOutput()
+
+		// Show deprecation warnings after the output
+		if common.OutputFormat != "json" && common.OutputFormat != "custom" {
+			showDatabaseDeprecationWarnings(databases.Items...)
+		}
 	},
 }

--- a/cmd/database/database_show.go
+++ b/cmd/database/database_show.go
@@ -74,6 +74,8 @@ var dbShowCmd = &cobra.Command{
 		default:
 			ow.WriteKeyValues()
 			fmt.Println("To get the credentials, run : civo db credential", db.Name)
+			fmt.Println()
+			showDatabaseDeprecationWarnings(*db)
 		}
 	},
 }

--- a/cmd/database/database_update.go
+++ b/cmd/database/database_update.go
@@ -56,7 +56,7 @@ var dbUpdateCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			fmt.Printf("The Database %s was updated\n", utility.Green(findDB.Name))
-			os.Exit(0)
+			showDatabaseDeprecationWarnings(*findDB)
 		}
 	},
 }


### PR DESCRIPTION
This adds some warning when viewing or interacting with databases that have a deprecated software and version.