### PR TITLE
Upgrade civogo dependency and remove KFaaS endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.24.0
+go 1.24.7
 
 module github.com/civo/cli
 
@@ -7,7 +7,7 @@ require (
 	github.com/adhocore/gronx v1.19.5
 	github.com/alejandrojnm/go-pluralize v0.1.0
 	github.com/briandowns/spinner v1.23.2
-	github.com/civo/civogo v0.6.4
+	github.com/civo/civogo v0.6.5
 	github.com/google/go-github/v57 v57.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c h1:aprLqMn7gSPT+vd
 github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c/go.mod h1:Ie6SubJv/NTO9Q0UBH0QCl3Ve50lu9hjbi5YJUw03TE=
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
 github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
-github.com/civo/civogo v0.6.4 h1:f77SHuXcVuUAm1famdtN9YUMP+eA9myyxAgRmepY9uQ=
-github.com/civo/civogo v0.6.4/go.mod h1:LaEbkszc+9nXSh4YNG0sYXFGYqdQFmXXzQg0gESs2hc=
+github.com/civo/civogo v0.6.5 h1:nS5TWJB2BnW1X26wN/nWGxYMgj6VEyZxSt/1OlKrQZw=
+github.com/civo/civogo v0.6.5/go.mod h1:akFVdRAQfJi4t8pGduUOiBwaW/NSC9i45m/dzhF09AY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=

--- a/utility/check.go
+++ b/utility/check.go
@@ -183,12 +183,6 @@ func CheckAvailability(resource string, regionSet string) (bool, string, error) 
 		}
 	}
 
-	if resource == "kfaas" {
-		if defaultRegion.Features.KFaaS && !defaultRegion.OutOfCapacity {
-			return true, "", nil
-		}
-	}
-
 	return false, defaultRegion.Code, nil
 }
 


### PR DESCRIPTION
This commit upgrades the civogo dependency from v0.6.4 to v0.6.5, which removes KFaaS endpoints. As a result, we've removed the KFaaS availability check from the utility/check.go file.

Changes:
- Updated civogo dependency from v0.6.4 to v0.6.5
- Removed KFaaS resource availability check in CheckAvailability function
- Updated Go version requirement to 1.24.7 (civogo v0.6.5 requires >= 1.24.9)

Note: Building this requires Go 1.24.9 or later due to civogo requirements.