### PR TITLE
fix: use pull request mode for homebrew formula updates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,12 @@ brews:
     repository:
       owner: civo
       name: homebrew-tools
+      pull_request:
+        enabled: true
+        base:
+          owner: civo
+          name: homebrew-tools
+          branch: master
     commit_author:
       name: civobot
       email: hello@civo.com


### PR DESCRIPTION
Switch goreleaser brews configuration from direct push to PR mode to comply with branch protection rules on civo/homebrew-tools.