### PR TITLE
fix: update Go version in goreleaser-check workflow

### DIFF
--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ vars.GO_VERSION || '1.24.13' }}
+          go-version: ${{ vars.GO_VERSION || '1.25.9' }}
           cache: true
 
       - name: Run GoReleaser Check


### PR DESCRIPTION
## Summary

- The goreleaser-check workflow was missed in the Go 1.25.9 upgrade (#583) and still defaults to Go 1.24.13
- With `GOTOOLCHAIN=local`, Go 1.24.13 refuses to build because `go.mod` now requires `go 1.25.9`

One-line change: `1.24.13` → `1.25.9` in `.github/workflows/goreleaser-check.yml`.

## Test plan

- [x] GoReleaser Check passes on this PR