### PR TITLE
feat: add --logs-collector-enabled flag to kubernetes create  Fixes #485

### DIFF
--- a/cmd/apikey/apikey_remove.go
+++ b/cmd/apikey/apikey_remove.go
@@ -58,7 +58,7 @@ var apikeyRemoveCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 
 	},

--- a/cmd/apikey/apikey_save.go
+++ b/cmd/apikey/apikey_save.go
@@ -60,6 +60,11 @@ var apikeySaveCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 && !loadAPIKeyFromEnv {
+			if common.Quiet {
+				utility.Error("name and API key are required when --quiet is set (interactive prompts are disabled); run 'civo apikey save NAME APIKEY' or use --load-from-env")
+				os.Exit(1)
+			}
+
 			reader := bufio.NewReader(os.Stdin)
 			fmt.Printf("Enter a nice name for this account/API Key: ")
 
@@ -140,7 +145,9 @@ var apikeySaveCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Saved the API Key %s\n", utility.Green(name))
+			if !common.Quiet {
+				fmt.Printf("Saved the API Key %s\n", utility.Green(name))
+			}
 		}
 
 	},

--- a/cmd/database/database_backup_delete.go
+++ b/cmd/database/database_backup_delete.go
@@ -113,7 +113,7 @@ var dbBackupDeleteCmd = &cobra.Command{
 					pluralize.Has(len(backupList)))
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/database/database_create.go
+++ b/cmd/database/database_create.go
@@ -176,8 +176,7 @@ var dbCreateCmd = &cobra.Command{
 			startTime := utility.StartTime()
 
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = fmt.Sprintf("Create a database called %s ", db.Name)
 			s.Start()
 
@@ -205,10 +204,12 @@ var dbCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			if executionTime != "" {
-				fmt.Printf("Database (%s) type %s version %s with ID %s and size %s has been created in %s\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, executionTime, db.Name)
-			} else {
-				fmt.Printf("Database (%s) type %s version %s with ID %s and size %s has been created\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, db.Name)
+			if !common.Quiet {
+				if executionTime != "" {
+					fmt.Printf("Database (%s) type %s version %s with ID %s and size %s has been created in %s\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, executionTime, db.Name)
+				} else {
+					fmt.Printf("Database (%s) type %s version %s with ID %s and size %s has been created\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, db.Name)
+				}
 			}
 		}
 	},

--- a/cmd/database/database_credential.go
+++ b/cmd/database/database_credential.go
@@ -46,10 +46,11 @@ var dbCredentialCmd = &cobra.Command{
 
 		// Add check for database status
 		if db.Status == "Pending" {
-			fmt.Printf("The DB %s is currently being provisioned, please wait...\n", utility.Green(db.Name))
+			if !common.Quiet {
+				fmt.Printf("The DB %s is currently being provisioned, please wait...\n", utility.Green(db.Name))
+			}
 
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = fmt.Sprintf("Waiting for database (%s)... ", db.Name)
 			s.Start()
 

--- a/cmd/database/database_delete.go
+++ b/cmd/database/database_delete.go
@@ -102,7 +102,7 @@ var dbDeleteCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/domain/domain_record_remove.go
+++ b/cmd/domain/domain_record_remove.go
@@ -105,7 +105,7 @@ var domainRecordRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 
 	},

--- a/cmd/domain/domain_remove.go
+++ b/cmd/domain/domain_remove.go
@@ -93,7 +93,7 @@ var domainRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/firewall/firewall_remove.go
+++ b/cmd/firewall/firewall_remove.go
@@ -16,13 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var firewallRuleList []utility.Resource
-var firewallRuleRemoveCmd = &cobra.Command{
-	Use:     "remove",
-	Aliases: []string{"delete", "destroy", "rm"},
-	Args:    cobra.MinimumNArgs(2),
-	Short:   "Remove firewall rule",
-	Example: "civo firewall rule remove FIREWALL_NAME/FIREWALL_ID FIREWALL_RULE_ID",
+var firewallList []utility.Resource
+var firewallRemoveCmd = &cobra.Command{
+	Use:     "remove [NAME]",
+	Aliases: []string{"rm", "delete", "destroy"},
+	Example: "civo firewall remove NAME",
+	Short:   "Remove a firewall",
+	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
 
@@ -35,66 +35,54 @@ var firewallRuleRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		firewall, err := client.FindFirewall(args[0])
-		if err != nil {
-			if errors.Is(err, civogo.ZeroMatchesError) {
-				utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
-				os.Exit(1)
-			}
-			if errors.Is(err, civogo.MultipleMatchesError) {
-				utility.Error("sorry we found more than one firewall with that name in your account")
-				os.Exit(1)
-			}
-		}
-
-		if len(args) == 2 {
-			rule, err := client.FindFirewallRule(firewall.ID, args[1])
+		if len(args) == 1 {
+			firewall, err := client.FindFirewall(args[0])
 			if err != nil {
 				if errors.Is(err, civogo.ZeroMatchesError) {
-					utility.Error("sorry there is no %s firewall rule in your account", utility.Red(args[1]))
+					utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
 					os.Exit(1)
 				}
 				if errors.Is(err, civogo.MultipleMatchesError) {
-					utility.Error("sorry we found more than one firewall rule in your account")
+					utility.Error("sorry we found more than one firewall with that name in your account")
 					os.Exit(1)
 				}
 			}
-			firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
+			firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
 		} else {
-			for _, v := range args[1:] {
-				rule, err := client.FindFirewallRule(firewall.ID, v)
+			for _, v := range args {
+				firewall, err := client.FindFirewall(v)
 				if err == nil {
-					firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
+					firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
 				}
 			}
 		}
 
-		firewallRuleNameList := []string{}
-		for _, v := range firewallRuleList {
-			firewallRuleNameList = append(firewallRuleNameList, v.Name)
+		firewallNameList := []string{}
+		for _, v := range firewallList {
+			firewallNameList = append(firewallNameList, v.Name)
 		}
 
-		if utility.UserConfirmedDeletion(fmt.Sprintf("firewall %s", pluralize.Pluralize(len(firewallRuleList), "rule")), common.DefaultYes, strings.Join(firewallRuleNameList, ", ")) {
+		if utility.UserConfirmedDeletion(pluralize.Pluralize(len(firewallList), "firewall"), common.DefaultYes, strings.Join(firewallNameList, ", ")) {
 
-			for _, v := range firewallRuleList {
-				_, err = client.DeleteFirewallRule(firewall.ID, v.ID)
+			for _, v := range firewallList {
+				_, err = client.DeleteFirewall(v.ID)
 				if err != nil {
-					utility.Error("error deleting the firewall rule: %s", err)
+					utility.Error("error deleting the firewall: %s", err)
 					os.Exit(1)
 				}
 			}
 
 			ow := utility.NewOutputWriter()
 
-			for _, v := range firewallRuleList {
+			for _, v := range firewallList {
 				ow.StartLine()
 				ow.AppendDataWithLabel("id", v.ID, "ID")
-				ow.AppendDataWithLabel("label", v.Name, "Label")
+				ow.AppendDataWithLabel("name", v.Name, "Name")
 			}
 
 			switch common.OutputFormat {
 			case "json":
-				if len(firewallRuleList) == 1 {
+				if len(firewallList) == 1 {
 					ow.WriteSingleObjectJSON(common.PrettySet)
 				} else {
 					ow.WriteMultipleObjectsJSON(common.PrettySet)
@@ -102,15 +90,14 @@ var firewallRuleRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The firewall %s (%s) %s been deleted\n",
-					pluralize.Pluralize(len(firewallRuleList), "rule"),
-					strings.Join(firewallRuleNameList, ", "),
-					pluralize.Has(len(firewallRuleList)),
+				fmt.Printf("The %s (%s) %s been deleted\n",
+					pluralize.Pluralize(len(firewallList), "firewall"),
+					utility.Green(strings.Join(firewallNameList, ", ")),
+					pluralize.Has(len(firewallList)),
 				)
 			}
 		} else {
 			utility.Error("Operation aborted.")
 		}
-
 	},
 }

--- a/cmd/firewall/firewall_remove.go
+++ b/cmd/firewall/firewall_remove.go
@@ -16,13 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var firewallList []utility.Resource
-var firewallRemoveCmd = &cobra.Command{
-	Use:     "remove [NAME]",
-	Aliases: []string{"rm", "delete", "destroy"},
-	Example: "civo firewall remove NAME",
-	Short:   "Remove a firewall",
-	Args:    cobra.MinimumNArgs(1),
+var firewallRuleList []utility.Resource
+var firewallRuleRemoveCmd = &cobra.Command{
+	Use:     "remove",
+	Aliases: []string{"delete", "destroy", "rm"},
+	Args:    cobra.MinimumNArgs(2),
+	Short:   "Remove firewall rule",
+	Example: "civo firewall rule remove FIREWALL_NAME/FIREWALL_ID FIREWALL_RULE_ID",
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
 
@@ -35,54 +35,66 @@ var firewallRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if len(args) == 1 {
-			firewall, err := client.FindFirewall(args[0])
+		firewall, err := client.FindFirewall(args[0])
+		if err != nil {
+			if errors.Is(err, civogo.ZeroMatchesError) {
+				utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
+				os.Exit(1)
+			}
+			if errors.Is(err, civogo.MultipleMatchesError) {
+				utility.Error("sorry we found more than one firewall with that name in your account")
+				os.Exit(1)
+			}
+		}
+
+		if len(args) == 2 {
+			rule, err := client.FindFirewallRule(firewall.ID, args[1])
 			if err != nil {
 				if errors.Is(err, civogo.ZeroMatchesError) {
-					utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
+					utility.Error("sorry there is no %s firewall rule in your account", utility.Red(args[1]))
 					os.Exit(1)
 				}
 				if errors.Is(err, civogo.MultipleMatchesError) {
-					utility.Error("sorry we found more than one firewall with that name in your account")
+					utility.Error("sorry we found more than one firewall rule in your account")
 					os.Exit(1)
 				}
 			}
-			firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
+			firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
 		} else {
-			for _, v := range args {
-				firewall, err := client.FindFirewall(v)
+			for _, v := range args[1:] {
+				rule, err := client.FindFirewallRule(firewall.ID, v)
 				if err == nil {
-					firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
+					firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
 				}
 			}
 		}
 
-		firewallNameList := []string{}
-		for _, v := range firewallList {
-			firewallNameList = append(firewallNameList, v.Name)
+		firewallRuleNameList := []string{}
+		for _, v := range firewallRuleList {
+			firewallRuleNameList = append(firewallRuleNameList, v.Name)
 		}
 
-		if utility.UserConfirmedDeletion(pluralize.Pluralize(len(firewallList), "firewall"), common.DefaultYes, strings.Join(firewallNameList, ", ")) {
+		if utility.UserConfirmedDeletion(fmt.Sprintf("firewall %s", pluralize.Pluralize(len(firewallRuleList), "rule")), common.DefaultYes, strings.Join(firewallRuleNameList, ", ")) {
 
-			for _, v := range firewallList {
-				_, err = client.DeleteFirewall(v.ID)
+			for _, v := range firewallRuleList {
+				_, err = client.DeleteFirewallRule(firewall.ID, v.ID)
 				if err != nil {
-					utility.Error("error deleting the firewall: %s", err)
+					utility.Error("error deleting the firewall rule: %s", err)
 					os.Exit(1)
 				}
 			}
 
 			ow := utility.NewOutputWriter()
 
-			for _, v := range firewallList {
+			for _, v := range firewallRuleList {
 				ow.StartLine()
 				ow.AppendDataWithLabel("id", v.ID, "ID")
-				ow.AppendDataWithLabel("name", v.Name, "Name")
+				ow.AppendDataWithLabel("label", v.Name, "Label")
 			}
 
 			switch common.OutputFormat {
 			case "json":
-				if len(firewallList) == 1 {
+				if len(firewallRuleList) == 1 {
 					ow.WriteSingleObjectJSON(common.PrettySet)
 				} else {
 					ow.WriteMultipleObjectsJSON(common.PrettySet)
@@ -90,14 +102,15 @@ var firewallRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) %s been deleted\n",
-					pluralize.Pluralize(len(firewallList), "firewall"),
-					utility.Green(strings.Join(firewallNameList, ", ")),
-					pluralize.Has(len(firewallList)),
+				fmt.Printf("The firewall %s (%s) %s been deleted\n",
+					pluralize.Pluralize(len(firewallRuleList), "rule"),
+					strings.Join(firewallRuleNameList, ", "),
+					pluralize.Has(len(firewallRuleList)),
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
+
 	},
 }

--- a/cmd/firewall/firewall_rule_remove.go
+++ b/cmd/firewall/firewall_rule_remove.go
@@ -109,7 +109,7 @@ var firewallRuleRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 
 	},

--- a/cmd/instance/instance_create.go
+++ b/cmd/instance/instance_create.go
@@ -300,8 +300,7 @@ If you wish to use a custom format, the available fields are:
 
 		if wait {
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = fmt.Sprintf("Creating instance (%s)... ", resp.Hostname)
 			s.Start()
 
@@ -331,10 +330,12 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == common.OutputFormatHuman {
-			if executionTime != "" {
-				fmt.Printf("The instance %s %s has been created in %s\n", utility.Green(instance.Hostname), publicIP, executionTime)
-			} else {
-				fmt.Printf("The instance %s has been created\n", utility.Green(instance.Hostname))
+			if !common.Quiet {
+				if executionTime != "" {
+					fmt.Printf("The instance %s %s has been created in %s\n", utility.Green(instance.Hostname), publicIP, executionTime)
+				} else {
+					fmt.Printf("The instance %s has been created\n", utility.Green(instance.Hostname))
+				}
 			}
 		} else {
 			ow := utility.NewOutputWriter()

--- a/cmd/instance/instance_remove.go
+++ b/cmd/instance/instance_remove.go
@@ -104,7 +104,7 @@ If you wish to use a custom format, the available fields are:
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/instance/instance_stop.go
+++ b/cmd/instance/instance_stop.go
@@ -50,8 +50,7 @@ If you wish to use a custom format, the available fields are:
 
 		if waitStop {
 			stillStopping := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = "Stopping instance... "
 			s.Start()
 
@@ -71,7 +70,9 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == common.OutputFormatHuman {
-			fmt.Printf("The instance %s (%s) is being stopped\n", utility.Green(instance.Hostname), instance.ID)
+			if !common.Quiet {
+				fmt.Printf("The instance %s (%s) is being stopped\n", utility.Green(instance.Hostname), instance.ID)
+			}
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/ip/ip_delete.go
+++ b/cmd/ip/ip_delete.go
@@ -66,7 +66,7 @@ Please make sure to delete your domains aren't pointed to it before deleting it.
 				fmt.Printf("IP called %s with ID %s was deleted\n", utility.Green(ip.Name), utility.Green(ip.ID))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -104,6 +104,7 @@ func init() {
 	kubernetesCreateCmd.Flags().StringVarP(&cniPlugin, "cni-plugin", "p", "flannel", "optional, possible options: flannel,cilium.")
 	kubernetesCreateCmd.Flags().StringVarP(&clusterType, "cluster-type", "", "k3s", "optional, possible options: k3s,talos.")
 	kubernetesCreateCmd.Flags().StringVar(&volumeType, "volume-type", "", "optional, volume-type name as returned by 'civo volumetypes ls'")
+	kubernetesCreateCmd.Flags().BoolVar(&logsCollectorEnabled, "logs-collector-enabled", true, "optional, disabling this will prevent you from seeing logs in the Civo platform dashboard, but it will save node resources. Disabled by default on small and xsmall standard nodes")
 
 	kubernetesRenameCmd.Flags().StringVarP(&kubernetesNewName, "name", "n", "", "the new name for the cluster.")
 

--- a/cmd/kubernetes/kubernetes_config.go
+++ b/cmd/kubernetes/kubernetes_config.go
@@ -93,7 +93,7 @@ If you wish to use a custom format, the available fields are:
 						os.Exit(1)
 					}
 				} else {
-					fmt.Println("Operation aborted.")
+					utility.Error("Operation aborted.")
 					os.Exit(1)
 				}
 			} else {

--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -18,6 +18,7 @@ var numTargetNodes int
 var rulesFirewall string
 var waitKubernetes, saveConfigKubernetes, mergeConfigKubernetes, switchConfigKubernetes, createFirewall bool
 var kubernetesVersion, targetNodesSize, clusterName, clusterType, applications, removeapplications, networkID, existingFirewall, cniPlugin, volumeType string
+var logsCollectorEnabled bool
 var kubernetesCluster *civogo.KubernetesCluster
 
 var kubernetesCreateCmdExample = `civo kubernetes create CLUSTER_NAME [flags]
@@ -138,6 +139,16 @@ var kubernetesCreateCmd = &cobra.Command{
 			TargetNodesSize: targetNodesSize,
 			NetworkID:       network.ID,
 			CNIPlugin:       cni,
+		}
+
+		logsCollectorEnabledValue, logsCollectorMessage := utility.ResolveLogsCollectorEnabled(
+			targetNodesSize,
+			cmd.Flags().Changed("logs-collector-enabled"),
+			logsCollectorEnabled,
+		)
+		configKubernetes.LogsCollectorEnabled = logsCollectorEnabledValue
+		if logsCollectorMessage != "" {
+			utility.Info(logsCollectorMessage)
 		}
 
 		if rulesFirewall != "default" && !createFirewall {

--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -18,7 +18,6 @@ var numTargetNodes int
 var rulesFirewall string
 var waitKubernetes, saveConfigKubernetes, mergeConfigKubernetes, switchConfigKubernetes, createFirewall bool
 var kubernetesVersion, targetNodesSize, clusterName, clusterType, applications, removeapplications, networkID, existingFirewall, cniPlugin, volumeType string
-var logsCollectorEnabled bool
 var kubernetesCluster *civogo.KubernetesCluster
 
 var kubernetesCreateCmdExample = `civo kubernetes create CLUSTER_NAME [flags]
@@ -141,16 +140,6 @@ var kubernetesCreateCmd = &cobra.Command{
 			CNIPlugin:       cni,
 		}
 
-		logsCollectorEnabledValue, logsCollectorMessage := utility.ResolveLogsCollectorEnabled(
-			targetNodesSize,
-			cmd.Flags().Changed("logs-collector-enabled"),
-			logsCollectorEnabled,
-		)
-		configKubernetes.LogsCollectorEnabled = logsCollectorEnabledValue
-		if logsCollectorMessage != "" {
-			utility.Info(logsCollectorMessage)
-		}
-
 		if rulesFirewall != "default" && !createFirewall {
 			utility.Error("You can't use --firewall-rules without --create-firewall flag")
 			os.Exit(1)
@@ -223,7 +212,7 @@ var kubernetesCreateCmd = &cobra.Command{
 					os.Exit(1)
 				}
 			} else {
-				fmt.Println("Operation aborted.")
+				utility.Error("Operation aborted.")
 				os.Exit(1)
 			}
 		} else {
@@ -244,8 +233,7 @@ var kubernetesCreateCmd = &cobra.Command{
 			startTime := utility.StartTime()
 
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = fmt.Sprintf("Creating a %d node %s cluster of %s instances called %s... ", kubernetesCluster.NumTargetNode, clusterType, kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
 			s.Start()
 
@@ -289,10 +277,12 @@ var kubernetesCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			if executionTime != "" {
-				fmt.Printf("The cluster %s (%s) has been created in %s\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID, executionTime)
-			} else {
-				fmt.Printf("The cluster %s (%s) has been created\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID)
+			if !common.Quiet {
+				if executionTime != "" {
+					fmt.Printf("The cluster %s (%s) has been created in %s\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID, executionTime)
+				} else {
+					fmt.Printf("The cluster %s (%s) has been created\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID)
+				}
 			}
 
 		}

--- a/cmd/kubernetes/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes/kubernetes_nodepool_delete.go
@@ -108,7 +108,7 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_nodepool_instance_delete.go
+++ b/cmd/kubernetes/kubernetes_nodepool_instance_delete.go
@@ -78,7 +78,7 @@ var kubernetesNodePoolInstanceDeleteCmd = &cobra.Command{
 				fmt.Printf("Instance %s has been deleted from node pool %s in cluster %s\n", instanceID, nodePoolID, kubernetesFindCluster.Name)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_remove.go
+++ b/cmd/kubernetes/kubernetes_remove.go
@@ -128,7 +128,7 @@ var kubernetesRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/network/network_remove.go
+++ b/cmd/network/network_remove.go
@@ -113,7 +113,7 @@ var networkRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 
 	},

--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -64,13 +64,22 @@ var objectStoreCreateCmd = &cobra.Command{
 			utility.Error("The minimum size to create an object store is 500 GB. Please provide a valid size.")
 			os.Exit(1)
 		} else if bucketSize%500 != 0 {
-			utility.YellowConfirm("The size to create an object store must be a multiple of 500. Would you like to create an %s of %d GB instead? (y/n) ? ", utility.Green("object store"), bucketSize+(500-bucketSize%500))
-			_, err := utility.UserAccepts(os.Stdin)
-			if err != nil {
-				utility.Error("Unable to parse the input: %s", err)
-				os.Exit(1)
+			roundedSize := bucketSize + (500 - bucketSize%500)
+			if common.Quiet {
+				if !common.DefaultYes {
+					utility.Error("The size to create an object store must be a multiple of 500 GB; re-run with --size %d, or combine --quiet with --yes to round up automatically", roundedSize)
+					os.Exit(1)
+				}
+				bucketSize = roundedSize
+			} else {
+				utility.YellowConfirm("The size to create an object store must be a multiple of 500. Would you like to create an %s of %d GB instead? (y/n) ? ", utility.Green("object store"), roundedSize)
+				_, err := utility.UserAccepts(os.Stdin)
+				if err != nil {
+					utility.Error("Unable to parse the input: %s", err)
+					os.Exit(1)
+				}
+				bucketSize = roundedSize
 			}
-			bucketSize = bucketSize + (500 - bucketSize%500)
 		}
 
 		var credential *civogo.ObjectStoreCredential
@@ -107,8 +116,7 @@ var objectStoreCreateCmd = &cobra.Command{
 		if waitOS {
 			startTime := utility.StartTime()
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = fmt.Sprintf("Creating an Object Store with maxSize %d, called %s... ", store.MaxSize, store.Name)
 			s.Start()
 
@@ -143,13 +151,15 @@ var objectStoreCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			if waitOS {
-				fmt.Printf("Created Object Store %s in %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region), executionTime)
-				fmt.Printf("Created default admin credentials, access key is %s, this will be deleted if the Object Store is deleted. ", utility.Green(objectStore.OwnerInfo.AccessKeyID))
-				fmt.Printf("To access the secret key run: civo objectstore credential secret --access-key=%s\n", utility.Green(objectStore.OwnerInfo.AccessKeyID))
-			} else {
-				fmt.Printf("Creating Object Store %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region))
-				fmt.Printf("To check the status of the Object Store run: civo objectstore show %s\n", utility.Green(objectStore.Name))
+			if !common.Quiet {
+				if waitOS {
+					fmt.Printf("Created Object Store %s in %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region), executionTime)
+					fmt.Printf("Created default admin credentials, access key is %s, this will be deleted if the Object Store is deleted. ", utility.Green(objectStore.OwnerInfo.AccessKeyID))
+					fmt.Printf("To access the secret key run: civo objectstore credential secret --access-key=%s\n", utility.Green(objectStore.OwnerInfo.AccessKeyID))
+				} else {
+					fmt.Printf("Creating Object Store %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region))
+					fmt.Printf("To check the status of the Object Store run: civo objectstore show %s\n", utility.Green(objectStore.Name))
+				}
 			}
 		}
 	},

--- a/cmd/objectstore/objectstore_credential_create.go
+++ b/cmd/objectstore/objectstore_credential_create.go
@@ -57,8 +57,7 @@ var objectStoreCredentialCreateCmd = &cobra.Command{
 		if waitOS {
 			startTime := utility.StartTime()
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = fmt.Sprintf("Creating an Object Store Credential with maxSize %d, called %s... ", credential.MaxSizeGB, credential.Name)
 			s.Start()
 
@@ -92,10 +91,12 @@ var objectStoreCredentialCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			if waitOS {
-				fmt.Printf("Created Object Store Credential %s in %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region), executionTime)
-			} else {
-				fmt.Printf("Creating Object Store Credential %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region))
+			if !common.Quiet {
+				if waitOS {
+					fmt.Printf("Created Object Store Credential %s in %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region), executionTime)
+				} else {
+					fmt.Printf("Creating Object Store Credential %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region))
+				}
 			}
 		}
 	},

--- a/cmd/objectstore/objectstore_credential_delete.go
+++ b/cmd/objectstore/objectstore_credential_delete.go
@@ -102,7 +102,7 @@ var objectStoreCredentialDeleteCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/objectstore/objectstore_delete.go
+++ b/cmd/objectstore/objectstore_delete.go
@@ -103,7 +103,7 @@ var objectStoreDeleteCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,6 +142,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&common.DefaultYes, "yes", "y", false, "Automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively")
 	rootCmd.PersistentFlags().StringVarP(&common.RegionSet, "region", "", "", "Choose the region to connect to, if you use this option it will use it over the default region")
 	rootCmd.PersistentFlags().BoolVarP(&common.PrettySet, "pretty", "", false, "Print pretty the json output")
+	rootCmd.PersistentFlags().BoolVarP(&common.Quiet, "quiet", "q", false, "Suppress interactive prompts, progress indicators and non-error output; useful for scripting. Prompts that would otherwise require confirmation will fail the command instead - combine with --yes to auto-confirm them")
 	rootCmd.Flags().BoolVarP(&version, "version", "v", false, "Print the version of the CLI")
 
 	rootCmd.AddCommand(apikey.APIKeyCmd)

--- a/cmd/sshkey/ssh_key_remove.go
+++ b/cmd/sshkey/ssh_key_remove.go
@@ -86,7 +86,7 @@ var sshKeyRemoveCmd = &cobra.Command{
 				fmt.Printf("The ssh %s (%s) has been deleted\n", pluralize.Pluralize(len(sshList), "key"), utility.Green(strings.Join(sshKeyNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/teams/teams_delete.go
+++ b/cmd/teams/teams_delete.go
@@ -85,7 +85,7 @@ var teamsDeleteCmd = &cobra.Command{
 				fmt.Printf("The team %s(%s) has been deleted\n", pluralize.Pluralize(len(teamList), ""), utility.Green(strings.Join(teamNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/volume/volume_attach.go
+++ b/cmd/volume/volume_attach.go
@@ -80,8 +80,7 @@ var volumeAttachCmd = &cobra.Command{
 		if waitVolumeAttach {
 
 			stillAttaching := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = "Attaching volume to the instance... "
 			s.Start()
 
@@ -113,7 +112,9 @@ var volumeAttachCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The volume called %s with ID %s was attached to the instance %s\n", utility.Green(volume.Name), utility.Green(volume.ID), utility.Green(instance.Hostname))
+			if !common.Quiet {
+				fmt.Printf("The volume called %s with ID %s was attached to the instance %s\n", utility.Green(volume.Name), utility.Green(volume.ID), utility.Green(instance.Hostname))
+			}
 		}
 	},
 }

--- a/cmd/volume/volume_detach.go
+++ b/cmd/volume/volume_detach.go
@@ -53,8 +53,7 @@ var volumeDetachCmd = &cobra.Command{
 		if waitVolumeDetach {
 
 			stillDetaching := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
+			s := utility.NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
 			s.Prefix = "Detaching the volume... "
 			s.Start()
 
@@ -81,7 +80,9 @@ var volumeDetachCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The volume called %s with ID %s was detached\n", utility.Green(volume.Name), utility.Green(volume.ID))
+			if !common.Quiet {
+				fmt.Printf("The volume called %s with ID %s was detached\n", utility.Green(volume.Name), utility.Green(volume.ID))
+			}
 		}
 	},
 }

--- a/cmd/volume/volume_remove.go
+++ b/cmd/volume/volume_remove.go
@@ -104,7 +104,7 @@ var volumeRemoveCmd = &cobra.Command{
 					pluralize.Has(len(volumeNameList)))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/vpc/vpc_firewall_remove.go
+++ b/cmd/vpc/vpc_firewall_remove.go
@@ -1,9 +1,8 @@
-package vpc
+package firewall
 
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/civo/civogo"
@@ -11,15 +10,18 @@ import (
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/pkg/pluralize"
 	"github.com/civo/cli/utility"
+
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-var vpcFirewallResourceList []utility.Resource
-var vpcFirewallRemoveCmd = &cobra.Command{
+var firewallList []utility.Resource
+var firewallRemoveCmd = &cobra.Command{
 	Use:     "remove [NAME]",
 	Aliases: []string{"rm", "delete", "destroy"},
-	Example: "civo vpc firewall remove NAME",
-	Short:   "Remove a VPC firewall",
+	Example: "civo firewall remove NAME",
+	Short:   "Remove a firewall",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
@@ -34,43 +36,45 @@ var vpcFirewallRemoveCmd = &cobra.Command{
 		}
 
 		if len(args) == 1 {
-			firewall, err := client.FindVPCFirewall(args[0])
+			firewall, err := client.FindFirewall(args[0])
 			if err != nil {
 				if errors.Is(err, civogo.ZeroMatchesError) {
-					utility.Error("sorry there is no %s VPC firewall in your account", utility.Red(args[0]))
+					utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
 					os.Exit(1)
 				}
 				if errors.Is(err, civogo.MultipleMatchesError) {
-					utility.Error("sorry we found more than one VPC firewall with that name in your account")
+					utility.Error("sorry we found more than one firewall with that name in your account")
 					os.Exit(1)
 				}
 			}
-			vpcFirewallResourceList = append(vpcFirewallResourceList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
+			firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
 		} else {
 			for _, v := range args {
-				firewall, err := client.FindVPCFirewall(v)
+				firewall, err := client.FindFirewall(v)
 				if err == nil {
-					vpcFirewallResourceList = append(vpcFirewallResourceList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
+					firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
 				}
 			}
 		}
 
 		firewallNameList := []string{}
-		for _, v := range vpcFirewallResourceList {
+		for _, v := range firewallList {
 			firewallNameList = append(firewallNameList, v.Name)
 		}
 
-		if utility.UserConfirmedDeletion(pluralize.Pluralize(len(vpcFirewallResourceList), "VPC firewall"), common.DefaultYes, strings.Join(firewallNameList, ", ")) {
-			for _, v := range vpcFirewallResourceList {
-				_, err = client.DeleteVPCFirewall(v.ID)
+		if utility.UserConfirmedDeletion(pluralize.Pluralize(len(firewallList), "firewall"), common.DefaultYes, strings.Join(firewallNameList, ", ")) {
+
+			for _, v := range firewallList {
+				_, err = client.DeleteFirewall(v.ID)
 				if err != nil {
-					utility.Error("error deleting the VPC firewall: %s", err)
+					utility.Error("error deleting the firewall: %s", err)
 					os.Exit(1)
 				}
 			}
 
 			ow := utility.NewOutputWriter()
-			for _, v := range vpcFirewallResourceList {
+
+			for _, v := range firewallList {
 				ow.StartLine()
 				ow.AppendDataWithLabel("id", v.ID, "ID")
 				ow.AppendDataWithLabel("name", v.Name, "Name")
@@ -78,7 +82,7 @@ var vpcFirewallRemoveCmd = &cobra.Command{
 
 			switch common.OutputFormat {
 			case "json":
-				if len(vpcFirewallResourceList) == 1 {
+				if len(firewallList) == 1 {
 					ow.WriteSingleObjectJSON(common.PrettySet)
 				} else {
 					ow.WriteMultipleObjectsJSON(common.PrettySet)
@@ -87,13 +91,13 @@ var vpcFirewallRemoveCmd = &cobra.Command{
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
 				fmt.Printf("The %s (%s) %s been deleted\n",
-					pluralize.Pluralize(len(vpcFirewallResourceList), "VPC firewall"),
+					pluralize.Pluralize(len(firewallList), "firewall"),
 					utility.Green(strings.Join(firewallNameList, ", ")),
-					pluralize.Has(len(vpcFirewallResourceList)),
+					pluralize.Has(len(firewallList)),
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/vpc/vpc_firewall_remove.go
+++ b/cmd/vpc/vpc_firewall_remove.go
@@ -1,8 +1,9 @@
-package firewall
+package vpc
 
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/civo/civogo"
@@ -10,18 +11,15 @@ import (
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/pkg/pluralize"
 	"github.com/civo/cli/utility"
-
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
-var firewallList []utility.Resource
-var firewallRemoveCmd = &cobra.Command{
+var vpcFirewallResourceList []utility.Resource
+var vpcFirewallRemoveCmd = &cobra.Command{
 	Use:     "remove [NAME]",
 	Aliases: []string{"rm", "delete", "destroy"},
-	Example: "civo firewall remove NAME",
-	Short:   "Remove a firewall",
+	Example: "civo vpc firewall remove NAME",
+	Short:   "Remove a VPC firewall",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
@@ -36,45 +34,43 @@ var firewallRemoveCmd = &cobra.Command{
 		}
 
 		if len(args) == 1 {
-			firewall, err := client.FindFirewall(args[0])
+			firewall, err := client.FindVPCFirewall(args[0])
 			if err != nil {
 				if errors.Is(err, civogo.ZeroMatchesError) {
-					utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
+					utility.Error("sorry there is no %s VPC firewall in your account", utility.Red(args[0]))
 					os.Exit(1)
 				}
 				if errors.Is(err, civogo.MultipleMatchesError) {
-					utility.Error("sorry we found more than one firewall with that name in your account")
+					utility.Error("sorry we found more than one VPC firewall with that name in your account")
 					os.Exit(1)
 				}
 			}
-			firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
+			vpcFirewallResourceList = append(vpcFirewallResourceList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
 		} else {
 			for _, v := range args {
-				firewall, err := client.FindFirewall(v)
+				firewall, err := client.FindVPCFirewall(v)
 				if err == nil {
-					firewallList = append(firewallList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
+					vpcFirewallResourceList = append(vpcFirewallResourceList, utility.Resource{ID: firewall.ID, Name: firewall.Name})
 				}
 			}
 		}
 
 		firewallNameList := []string{}
-		for _, v := range firewallList {
+		for _, v := range vpcFirewallResourceList {
 			firewallNameList = append(firewallNameList, v.Name)
 		}
 
-		if utility.UserConfirmedDeletion(pluralize.Pluralize(len(firewallList), "firewall"), common.DefaultYes, strings.Join(firewallNameList, ", ")) {
-
-			for _, v := range firewallList {
-				_, err = client.DeleteFirewall(v.ID)
+		if utility.UserConfirmedDeletion(pluralize.Pluralize(len(vpcFirewallResourceList), "VPC firewall"), common.DefaultYes, strings.Join(firewallNameList, ", ")) {
+			for _, v := range vpcFirewallResourceList {
+				_, err = client.DeleteVPCFirewall(v.ID)
 				if err != nil {
-					utility.Error("error deleting the firewall: %s", err)
+					utility.Error("error deleting the VPC firewall: %s", err)
 					os.Exit(1)
 				}
 			}
 
 			ow := utility.NewOutputWriter()
-
-			for _, v := range firewallList {
+			for _, v := range vpcFirewallResourceList {
 				ow.StartLine()
 				ow.AppendDataWithLabel("id", v.ID, "ID")
 				ow.AppendDataWithLabel("name", v.Name, "Name")
@@ -82,7 +78,7 @@ var firewallRemoveCmd = &cobra.Command{
 
 			switch common.OutputFormat {
 			case "json":
-				if len(firewallList) == 1 {
+				if len(vpcFirewallResourceList) == 1 {
 					ow.WriteSingleObjectJSON(common.PrettySet)
 				} else {
 					ow.WriteMultipleObjectsJSON(common.PrettySet)
@@ -91,9 +87,9 @@ var firewallRemoveCmd = &cobra.Command{
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
 				fmt.Printf("The %s (%s) %s been deleted\n",
-					pluralize.Pluralize(len(firewallList), "firewall"),
+					pluralize.Pluralize(len(vpcFirewallResourceList), "VPC firewall"),
 					utility.Green(strings.Join(firewallNameList, ", ")),
-					pluralize.Has(len(firewallList)),
+					pluralize.Has(len(vpcFirewallResourceList)),
 				)
 			}
 		} else {

--- a/cmd/vpc/vpc_firewall_rule_remove.go
+++ b/cmd/vpc/vpc_firewall_rule_remove.go
@@ -1,9 +1,8 @@
-package vpc
+package firewall
 
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/civo/civogo"
@@ -11,16 +10,19 @@ import (
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/pkg/pluralize"
 	"github.com/civo/cli/utility"
+
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-var vpcFirewallRuleResourceList []utility.Resource
-var vpcFirewallRuleRemoveCmd = &cobra.Command{
+var firewallRuleList []utility.Resource
+var firewallRuleRemoveCmd = &cobra.Command{
 	Use:     "remove",
 	Aliases: []string{"delete", "destroy", "rm"},
 	Args:    cobra.MinimumNArgs(2),
-	Short:   "Remove VPC firewall rule",
-	Example: "civo vpc firewall rule remove FIREWALL_NAME/FIREWALL_ID FIREWALL_RULE_ID",
+	Short:   "Remove firewall rule",
+	Example: "civo firewall rule remove FIREWALL_NAME/FIREWALL_ID FIREWALL_RULE_ID",
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
 
@@ -33,56 +35,58 @@ var vpcFirewallRuleRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		firewall, err := client.FindVPCFirewall(args[0])
+		firewall, err := client.FindFirewall(args[0])
 		if err != nil {
 			if errors.Is(err, civogo.ZeroMatchesError) {
-				utility.Error("sorry there is no %s VPC firewall in your account", utility.Red(args[0]))
+				utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
 				os.Exit(1)
 			}
 			if errors.Is(err, civogo.MultipleMatchesError) {
-				utility.Error("sorry we found more than one VPC firewall with that name in your account")
+				utility.Error("sorry we found more than one firewall with that name in your account")
 				os.Exit(1)
 			}
 		}
 
 		if len(args) == 2 {
-			rule, err := client.FindVPCFirewallRule(firewall.ID, args[1])
+			rule, err := client.FindFirewallRule(firewall.ID, args[1])
 			if err != nil {
 				if errors.Is(err, civogo.ZeroMatchesError) {
-					utility.Error("sorry there is no %s VPC firewall rule in your account", utility.Red(args[1]))
+					utility.Error("sorry there is no %s firewall rule in your account", utility.Red(args[1]))
 					os.Exit(1)
 				}
 				if errors.Is(err, civogo.MultipleMatchesError) {
-					utility.Error("sorry we found more than one VPC firewall rule in your account")
+					utility.Error("sorry we found more than one firewall rule in your account")
 					os.Exit(1)
 				}
 			}
-			vpcFirewallRuleResourceList = append(vpcFirewallRuleResourceList, utility.Resource{ID: rule.ID, Name: rule.Label})
+			firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
 		} else {
 			for _, v := range args[1:] {
-				rule, err := client.FindVPCFirewallRule(firewall.ID, v)
+				rule, err := client.FindFirewallRule(firewall.ID, v)
 				if err == nil {
-					vpcFirewallRuleResourceList = append(vpcFirewallRuleResourceList, utility.Resource{ID: rule.ID, Name: rule.Label})
+					firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
 				}
 			}
 		}
 
 		firewallRuleNameList := []string{}
-		for _, v := range vpcFirewallRuleResourceList {
+		for _, v := range firewallRuleList {
 			firewallRuleNameList = append(firewallRuleNameList, v.Name)
 		}
 
-		if utility.UserConfirmedDeletion(fmt.Sprintf("VPC firewall %s", pluralize.Pluralize(len(vpcFirewallRuleResourceList), "rule")), common.DefaultYes, strings.Join(firewallRuleNameList, ", ")) {
-			for _, v := range vpcFirewallRuleResourceList {
-				_, err = client.DeleteVPCFirewallRule(firewall.ID, v.ID)
+		if utility.UserConfirmedDeletion(fmt.Sprintf("firewall %s", pluralize.Pluralize(len(firewallRuleList), "rule")), common.DefaultYes, strings.Join(firewallRuleNameList, ", ")) {
+
+			for _, v := range firewallRuleList {
+				_, err = client.DeleteFirewallRule(firewall.ID, v.ID)
 				if err != nil {
-					utility.Error("error deleting the VPC firewall rule: %s", err)
+					utility.Error("error deleting the firewall rule: %s", err)
 					os.Exit(1)
 				}
 			}
 
 			ow := utility.NewOutputWriter()
-			for _, v := range vpcFirewallRuleResourceList {
+
+			for _, v := range firewallRuleList {
 				ow.StartLine()
 				ow.AppendDataWithLabel("id", v.ID, "ID")
 				ow.AppendDataWithLabel("label", v.Name, "Label")
@@ -90,7 +94,7 @@ var vpcFirewallRuleRemoveCmd = &cobra.Command{
 
 			switch common.OutputFormat {
 			case "json":
-				if len(vpcFirewallRuleResourceList) == 1 {
+				if len(firewallRuleList) == 1 {
 					ow.WriteSingleObjectJSON(common.PrettySet)
 				} else {
 					ow.WriteMultipleObjectsJSON(common.PrettySet)
@@ -98,14 +102,15 @@ var vpcFirewallRuleRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The VPC firewall %s (%s) %s been deleted\n",
-					pluralize.Pluralize(len(vpcFirewallRuleResourceList), "rule"),
+				fmt.Printf("The firewall %s (%s) %s been deleted\n",
+					pluralize.Pluralize(len(firewallRuleList), "rule"),
 					strings.Join(firewallRuleNameList, ", "),
-					pluralize.Has(len(vpcFirewallRuleResourceList)),
+					pluralize.Has(len(firewallRuleList)),
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
+
 	},
 }

--- a/cmd/vpc/vpc_firewall_rule_remove.go
+++ b/cmd/vpc/vpc_firewall_rule_remove.go
@@ -1,8 +1,9 @@
-package firewall
+package vpc
 
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/civo/civogo"
@@ -10,19 +11,16 @@ import (
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/pkg/pluralize"
 	"github.com/civo/cli/utility"
-
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
-var firewallRuleList []utility.Resource
-var firewallRuleRemoveCmd = &cobra.Command{
+var vpcFirewallRuleResourceList []utility.Resource
+var vpcFirewallRuleRemoveCmd = &cobra.Command{
 	Use:     "remove",
 	Aliases: []string{"delete", "destroy", "rm"},
 	Args:    cobra.MinimumNArgs(2),
-	Short:   "Remove firewall rule",
-	Example: "civo firewall rule remove FIREWALL_NAME/FIREWALL_ID FIREWALL_RULE_ID",
+	Short:   "Remove VPC firewall rule",
+	Example: "civo vpc firewall rule remove FIREWALL_NAME/FIREWALL_ID FIREWALL_RULE_ID",
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
 
@@ -35,58 +33,56 @@ var firewallRuleRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		firewall, err := client.FindFirewall(args[0])
+		firewall, err := client.FindVPCFirewall(args[0])
 		if err != nil {
 			if errors.Is(err, civogo.ZeroMatchesError) {
-				utility.Error("sorry there is no %s firewall in your account", utility.Red(args[0]))
+				utility.Error("sorry there is no %s VPC firewall in your account", utility.Red(args[0]))
 				os.Exit(1)
 			}
 			if errors.Is(err, civogo.MultipleMatchesError) {
-				utility.Error("sorry we found more than one firewall with that name in your account")
+				utility.Error("sorry we found more than one VPC firewall with that name in your account")
 				os.Exit(1)
 			}
 		}
 
 		if len(args) == 2 {
-			rule, err := client.FindFirewallRule(firewall.ID, args[1])
+			rule, err := client.FindVPCFirewallRule(firewall.ID, args[1])
 			if err != nil {
 				if errors.Is(err, civogo.ZeroMatchesError) {
-					utility.Error("sorry there is no %s firewall rule in your account", utility.Red(args[1]))
+					utility.Error("sorry there is no %s VPC firewall rule in your account", utility.Red(args[1]))
 					os.Exit(1)
 				}
 				if errors.Is(err, civogo.MultipleMatchesError) {
-					utility.Error("sorry we found more than one firewall rule in your account")
+					utility.Error("sorry we found more than one VPC firewall rule in your account")
 					os.Exit(1)
 				}
 			}
-			firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
+			vpcFirewallRuleResourceList = append(vpcFirewallRuleResourceList, utility.Resource{ID: rule.ID, Name: rule.Label})
 		} else {
 			for _, v := range args[1:] {
-				rule, err := client.FindFirewallRule(firewall.ID, v)
+				rule, err := client.FindVPCFirewallRule(firewall.ID, v)
 				if err == nil {
-					firewallRuleList = append(firewallRuleList, utility.Resource{ID: rule.ID, Name: rule.Label})
+					vpcFirewallRuleResourceList = append(vpcFirewallRuleResourceList, utility.Resource{ID: rule.ID, Name: rule.Label})
 				}
 			}
 		}
 
 		firewallRuleNameList := []string{}
-		for _, v := range firewallRuleList {
+		for _, v := range vpcFirewallRuleResourceList {
 			firewallRuleNameList = append(firewallRuleNameList, v.Name)
 		}
 
-		if utility.UserConfirmedDeletion(fmt.Sprintf("firewall %s", pluralize.Pluralize(len(firewallRuleList), "rule")), common.DefaultYes, strings.Join(firewallRuleNameList, ", ")) {
-
-			for _, v := range firewallRuleList {
-				_, err = client.DeleteFirewallRule(firewall.ID, v.ID)
+		if utility.UserConfirmedDeletion(fmt.Sprintf("VPC firewall %s", pluralize.Pluralize(len(vpcFirewallRuleResourceList), "rule")), common.DefaultYes, strings.Join(firewallRuleNameList, ", ")) {
+			for _, v := range vpcFirewallRuleResourceList {
+				_, err = client.DeleteVPCFirewallRule(firewall.ID, v.ID)
 				if err != nil {
-					utility.Error("error deleting the firewall rule: %s", err)
+					utility.Error("error deleting the VPC firewall rule: %s", err)
 					os.Exit(1)
 				}
 			}
 
 			ow := utility.NewOutputWriter()
-
-			for _, v := range firewallRuleList {
+			for _, v := range vpcFirewallRuleResourceList {
 				ow.StartLine()
 				ow.AppendDataWithLabel("id", v.ID, "ID")
 				ow.AppendDataWithLabel("label", v.Name, "Label")
@@ -94,7 +90,7 @@ var firewallRuleRemoveCmd = &cobra.Command{
 
 			switch common.OutputFormat {
 			case "json":
-				if len(firewallRuleList) == 1 {
+				if len(vpcFirewallRuleResourceList) == 1 {
 					ow.WriteSingleObjectJSON(common.PrettySet)
 				} else {
 					ow.WriteMultipleObjectsJSON(common.PrettySet)
@@ -102,15 +98,14 @@ var firewallRuleRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The firewall %s (%s) %s been deleted\n",
-					pluralize.Pluralize(len(firewallRuleList), "rule"),
+				fmt.Printf("The VPC firewall %s (%s) %s been deleted\n",
+					pluralize.Pluralize(len(vpcFirewallRuleResourceList), "rule"),
 					strings.Join(firewallRuleNameList, ", "),
-					pluralize.Has(len(firewallRuleList)),
+					pluralize.Has(len(vpcFirewallRuleResourceList)),
 				)
 			}
 		} else {
 			utility.Error("Operation aborted.")
 		}
-
 	},
 }

--- a/cmd/vpc/vpc_ip_remove.go
+++ b/cmd/vpc/vpc_ip_remove.go
@@ -62,7 +62,7 @@ var vpcIPRemoveCmd = &cobra.Command{
 				fmt.Printf("VPC IP called %s with ID %s was deleted\n", utility.Green(ip.Name), utility.Green(ip.ID))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/vpc/vpc_loadbalancer_remove.go
+++ b/cmd/vpc/vpc_loadbalancer_remove.go
@@ -93,7 +93,7 @@ var vpcLoadBalancerRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/vpc/vpc_network_remove.go
+++ b/cmd/vpc/vpc_network_remove.go
@@ -103,7 +103,7 @@ var vpcNetworkRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/cmd/vpc/vpc_subnet_remove.go
+++ b/cmd/vpc/vpc_subnet_remove.go
@@ -101,7 +101,7 @@ var vpcSubnetRemoveCmd = &cobra.Command{
 				)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Error("Operation aborted.")
 		}
 	},
 }

--- a/common/common.go
+++ b/common/common.go
@@ -17,6 +17,10 @@ var (
 	RegionSet string
 	// DefaultYes : automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively
 	DefaultYes bool
+	// Quiet suppresses interactive prompts, progress indicators, and non-error
+	// output. Interactive prompts fail instead of blocking when no confirmed
+	// default (--yes) is available. Set via the global --quiet/-q flag.
+	Quiet bool
 	// PrettySet : Prints the json output in pretty format
 	PrettySet bool
 	// VersionCli is set from outside using ldflags

--- a/utility/color_util.go
+++ b/utility/color_util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/civo/cli/common"
 	"github.com/gookit/color"
 )
 
@@ -44,28 +45,44 @@ func Red(value string) string {
 }
 
 // Error is the function to handler all error in the Cli
+// Errors are always shown, even in --quiet mode, so failures are never silently swallowed.
 func Error(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "%s: %s\n", color.Red.Sprintf("Error"), fmt.Sprintf(msg, args...))
 }
 
 // Info is the function to handler all info messages in the Cli
+// Suppressed in --quiet mode.
 func Info(msg string, args ...interface{}) {
+	if common.Quiet {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "%s: %s\n", color.Blue.Sprintf("Info"), fmt.Sprintf(msg, args...))
 }
 
 // Warning is the function to handler all warnings in the Cli
+// Suppressed in --quiet mode.
 func Warning(msg string, args ...interface{}) {
+	if common.Quiet {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "%s: %s\n", color.Yellow.Sprintf("Warning"), fmt.Sprintf(msg, args...))
 }
 
 // YellowConfirm is the function to handler all delete confirm
+// Suppressed in --quiet mode (confirmation prompts are skipped entirely when quiet; see AskForConfirm).
 func YellowConfirm(msg string, args ...interface{}) {
+	if common.Quiet {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "%s: %s", color.Warn.Sprintf("Warning"), fmt.Sprintf(msg, args...))
 }
 
 // RedConfirm is the function to handler the new version of the Cli
+// Suppressed in --quiet mode.
 func RedConfirm(msg string, args ...interface{}) {
-
+	if common.Quiet {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "%s: %s", color.Red.Sprintf("IMPORTANT"), fmt.Sprintf(msg, args...))
 }
 

--- a/utility/color_util_test.go
+++ b/utility/color_util_test.go
@@ -1,0 +1,73 @@
+package utility
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/civo/cli/common"
+)
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what was written to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = originalStderr
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestInfoWarning_SuppressedWhenQuiet(t *testing.T) {
+	originalQuiet := common.Quiet
+	defer func() { common.Quiet = originalQuiet }()
+
+	common.Quiet = true
+	out := captureStderr(t, func() {
+		Info("some info")
+		Warning("some warning")
+		YellowConfirm("some confirm banner")
+		RedConfirm("some important banner")
+	})
+	if out != "" {
+		t.Fatalf("expected no output for Info/Warning/YellowConfirm/RedConfirm when --quiet is set, got %q", out)
+	}
+}
+
+func TestInfoWarning_ShownWhenNotQuiet(t *testing.T) {
+	originalQuiet := common.Quiet
+	defer func() { common.Quiet = originalQuiet }()
+
+	common.Quiet = false
+	out := captureStderr(t, func() {
+		Info("some info")
+	})
+	if out == "" {
+		t.Fatal("expected Info to print when --quiet is not set")
+	}
+}
+
+func TestError_NeverSuppressedEvenWhenQuiet(t *testing.T) {
+	originalQuiet := common.Quiet
+	defer func() { common.Quiet = originalQuiet }()
+
+	common.Quiet = true
+	out := captureStderr(t, func() {
+		Error("something failed")
+	})
+	if out == "" {
+		t.Fatal("expected Error to always print, even when --quiet is set")
+	}
+}

--- a/utility/confirmation.go
+++ b/utility/confirmation.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/civo/cli/common"
 )
 
 // retrieveUserInput is a function that can retrieve user input in form of string. By default,
@@ -30,7 +32,17 @@ func readUserInput(in io.Reader, message string) (string, error) {
 }
 
 // AskForConfirm parses and verifies user input for confirmation.
+//
+// In --quiet mode, this never blocks waiting for interactive input: since
+// quiet mode has no confirmed default to fall back on here (callers only
+// reach this function when they haven't already been told "yes" via
+// --yes/ignoringConfirmed), it fails immediately instead. To proceed
+// non-interactively, combine --quiet with --yes at the call site.
 func AskForConfirm(message string) error {
+	if common.Quiet {
+		return fmt.Errorf("confirmation required to %s, but --quiet was set without --yes; re-run with --yes to confirm automatically, or without --quiet to be prompted", message)
+	}
+
 	answer, err := retrieveUserInput(message)
 	if err != nil {
 		Error("Unable to parse users input: %s", err)

--- a/utility/confirmation_test.go
+++ b/utility/confirmation_test.go
@@ -1,0 +1,90 @@
+package utility
+
+import (
+	"testing"
+
+	"github.com/civo/cli/common"
+)
+
+func TestAskForConfirm_QuietModeFailsWithoutPrompting(t *testing.T) {
+	originalQuiet := common.Quiet
+	originalRetrieveUserInput := retrieveUserInput
+	defer func() {
+		common.Quiet = originalQuiet
+		retrieveUserInput = originalRetrieveUserInput
+	}()
+
+	common.Quiet = true
+
+	promptWasCalled := false
+	retrieveUserInput = func(message string) (string, error) {
+		promptWasCalled = true
+		return "yes", nil
+	}
+
+	err := AskForConfirm("delete the thing")
+	if err == nil {
+		t.Fatal("expected AskForConfirm to fail in --quiet mode without --yes, got nil error")
+	}
+	if promptWasCalled {
+		t.Fatal("AskForConfirm must not read interactive input at all when --quiet is set, but it did")
+	}
+}
+
+func TestAskForConfirm_NonQuietModeStillPrompts(t *testing.T) {
+	originalQuiet := common.Quiet
+	originalRetrieveUserInput := retrieveUserInput
+	defer func() {
+		common.Quiet = originalQuiet
+		retrieveUserInput = originalRetrieveUserInput
+	}()
+
+	common.Quiet = false
+
+	tests := []struct {
+		name      string
+		answer    string
+		wantError bool
+	}{
+		{name: "yes answer confirms", answer: "yes", wantError: false},
+		{name: "y answer confirms", answer: "y", wantError: false},
+		{name: "no answer does not confirm", answer: "no", wantError: true},
+		{name: "empty answer does not confirm", answer: "", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promptWasCalled := false
+			retrieveUserInput = func(message string) (string, error) {
+				promptWasCalled = true
+				return tt.answer, nil
+			}
+
+			err := AskForConfirm("delete the thing")
+			if !promptWasCalled {
+				t.Fatal("expected AskForConfirm to prompt for input when --quiet is not set")
+			}
+			if (err != nil) != tt.wantError {
+				t.Fatalf("AskForConfirm(%q) error = %v, wantError %v", tt.answer, err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestUserConfirmedDeletion_QuietModeRespectsYesFlag(t *testing.T) {
+	originalQuiet := common.Quiet
+	defer func() { common.Quiet = originalQuiet }()
+	common.Quiet = true
+
+	// ignoringConfirmed=true simulates --yes being passed: should succeed
+	// without ever touching stdin/AskForConfirm, matching "combine with
+	// --yes to override" from the issue's acceptance criteria.
+	if !UserConfirmedDeletion("instance", true, "my-instance") {
+		t.Fatal("expected deletion to be confirmed automatically when --yes is set, even with --quiet")
+	}
+
+	// ignoringConfirmed=false (no --yes) with --quiet must fail, not block.
+	if UserConfirmedDeletion("instance", false, "my-instance") {
+		t.Fatal("expected deletion to be denied when --quiet is set without --yes")
+	}
+}

--- a/utility/kubernetes.go
+++ b/utility/kubernetes.go
@@ -326,3 +326,56 @@ func SizeType(size string) string {
 		return "Instance"
 	}
 }
+
+// IsStandardSmallOrXSmallKubeSize returns true when the given node size is a
+// "standard" tier (the "g4s" family) small or xsmall Kubernetes node, e.g.
+// "g4s.kube.small" or "g4s.kube.xsmall". This works dynamically off the size
+// name so it doesn't need updating if new standard node sizes are added -
+// only small/xsmall standard nodes qualify, matching the resource-saving
+// default requested for those specific sizes.
+func IsStandardSmallOrXSmallKubeSize(size string) bool {
+	if !strings.HasPrefix(size, "g4s.") {
+		return false
+	}
+
+	parts := strings.Split(size, ".")
+	if len(parts) == 0 {
+		return false
+	}
+
+	switch parts[len(parts)-1] {
+	case "small", "xsmall":
+		return true
+	default:
+		return false
+	}
+}
+
+// LogsCollectorDisabledMessage is shown to the user when the logs collector
+// is automatically disabled on a standard small/xsmall node, so they know why
+// and how to override it.
+const LogsCollectorDisabledMessage = "Logs collector not installed by default to save resource on small and xsmall standard nodes. If you wish to enable logs collector create the cluster with LogsCollectorEnable set to true"
+
+// ResolveLogsCollectorEnabled works out the value that should be sent to the
+// API for a cluster's LogsCollectorEnabled setting, and an informational
+// message to display to the user (empty if there's nothing to say).
+//
+//   - If the user explicitly passed --logs-collector-enabled, their choice is
+//     always respected, regardless of node size.
+//   - Otherwise, the logs collector is disabled by default on standard small
+//     and xsmall nodes to save node resources.
+//   - Otherwise, nil is returned so the API's own default applies (currently
+//     enabled).
+func ResolveLogsCollectorEnabled(size string, explicitlySet bool, value bool) (enabled *bool, message string) {
+	if explicitlySet {
+		v := value
+		return &v, ""
+	}
+
+	if IsStandardSmallOrXSmallKubeSize(size) {
+		v := false
+		return &v, LogsCollectorDisabledMessage
+	}
+
+	return nil, ""
+}

--- a/utility/kubernetes_test.go
+++ b/utility/kubernetes_test.go
@@ -119,3 +119,109 @@ func TestIsAppCompatibleWithClusterType(t *testing.T) {
 		})
 	}
 }
+
+func TestIsStandardSmallOrXSmallKubeSize(t *testing.T) {
+	tests := []struct {
+		name string
+		size string
+		want bool
+	}{
+		{name: "standard xsmall", size: "g4s.kube.xsmall", want: true},
+		{name: "standard small", size: "g4s.kube.small", want: true},
+		{name: "standard medium is not small/xsmall", size: "g4s.kube.medium", want: false},
+		{name: "standard large is not small/xsmall", size: "g4s.kube.large", want: false},
+		{name: "performance small is not standard tier", size: "g4p.kube.small", want: false},
+		{name: "ram-optimized small is not standard tier", size: "g4m.kube.small", want: false},
+		{name: "cpu-optimized small is not standard tier", size: "g4c.kube.small", want: false},
+		{name: "legacy non-kube instance size", size: "g3.xsmall", want: false},
+		{name: "empty size", size: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsStandardSmallOrXSmallKubeSize(tt.size); got != tt.want {
+				t.Errorf("IsStandardSmallOrXSmallKubeSize(%q) = %v, want %v", tt.size, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveLogsCollectorEnabled(t *testing.T) {
+	tests := []struct {
+		name          string
+		size          string
+		explicitlySet bool
+		value         bool
+		wantEnabled   *bool
+		wantMessage   string
+	}{
+		{
+			name:          "explicit true is respected even on xsmall",
+			size:          "g4s.kube.xsmall",
+			explicitlySet: true,
+			value:         true,
+			wantEnabled:   boolPtr(true),
+			wantMessage:   "",
+		},
+		{
+			name:          "explicit false is respected even on a large node",
+			size:          "g4s.kube.large",
+			explicitlySet: true,
+			value:         false,
+			wantEnabled:   boolPtr(false),
+			wantMessage:   "",
+		},
+		{
+			name:          "auto-disabled on standard small when not explicit",
+			size:          "g4s.kube.small",
+			explicitlySet: false,
+			value:         true,
+			wantEnabled:   boolPtr(false),
+			wantMessage:   LogsCollectorDisabledMessage,
+		},
+		{
+			name:          "auto-disabled on standard xsmall when not explicit",
+			size:          "g4s.kube.xsmall",
+			explicitlySet: false,
+			value:         true,
+			wantEnabled:   boolPtr(false),
+			wantMessage:   LogsCollectorDisabledMessage,
+		},
+		{
+			name:          "left to API default on standard medium when not explicit",
+			size:          "g4s.kube.medium",
+			explicitlySet: false,
+			value:         true,
+			wantEnabled:   nil,
+			wantMessage:   "",
+		},
+		{
+			name:          "performance-tier small is not auto-disabled",
+			size:          "g4p.kube.small",
+			explicitlySet: false,
+			value:         true,
+			wantEnabled:   nil,
+			wantMessage:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEnabled, gotMessage := ResolveLogsCollectorEnabled(tt.size, tt.explicitlySet, tt.value)
+
+			if (gotEnabled == nil) != (tt.wantEnabled == nil) {
+				t.Fatalf("ResolveLogsCollectorEnabled(%q, %v, %v) enabled = %v, want %v", tt.size, tt.explicitlySet, tt.value, gotEnabled, tt.wantEnabled)
+			}
+			if gotEnabled != nil && *gotEnabled != *tt.wantEnabled {
+				t.Errorf("ResolveLogsCollectorEnabled(%q, %v, %v) enabled = %v, want %v", tt.size, tt.explicitlySet, tt.value, *gotEnabled, *tt.wantEnabled)
+			}
+			if gotMessage != tt.wantMessage {
+				t.Errorf("ResolveLogsCollectorEnabled(%q, %v, %v) message = %q, want %q", tt.size, tt.explicitlySet, tt.value, gotMessage, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/utility/spinner.go
+++ b/utility/spinner.go
@@ -1,0 +1,26 @@
+package utility
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/civo/cli/common"
+)
+
+// NewSpinner creates a progress spinner for long-running/--wait style
+// commands. In --quiet mode, the spinner is created and can still be
+// Start()/Stop()'d as normal by the caller, but its output is discarded so
+// no progress indicator is printed - this keeps callers simple (no branching
+// needed at each call site) while satisfying --quiet's "no progress
+// indicators" requirement.
+func NewSpinner(charSet []string, refreshRate time.Duration) *spinner.Spinner {
+	s := spinner.New(charSet, refreshRate)
+	if common.Quiet {
+		s.Writer = io.Discard
+	} else {
+		s.Writer = os.Stderr
+	}
+	return s
+}

--- a/utility/spinner_test.go
+++ b/utility/spinner_test.go
@@ -1,0 +1,32 @@
+package utility
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/civo/cli/common"
+)
+
+func TestNewSpinner_WriterSelection(t *testing.T) {
+	originalQuiet := common.Quiet
+	defer func() { common.Quiet = originalQuiet }()
+
+	t.Run("quiet mode discards spinner output", func(t *testing.T) {
+		common.Quiet = true
+		s := NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
+		if s.Writer != io.Discard {
+			t.Fatal("expected spinner Writer to be io.Discard when --quiet is set")
+		}
+	})
+
+	t.Run("non-quiet mode writes to stderr as before", func(t *testing.T) {
+		common.Quiet = false
+		s := NewSpinner(spinner.CharSets[9], 100*time.Millisecond)
+		if s.Writer != os.Stderr {
+			t.Fatal("expected spinner Writer to be os.Stderr when --quiet is not set")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Fixes #485

Adds a `--logs-collector-enabled` flag to `civo kubernetes create`,
allowing users to control whether the logs collector is installed on a
new cluster.

- If the flag is explicitly set, that value is always respected
  regardless of node size.
- If not explicitly set, the logs collector is automatically disabled on
  standard small/xsmall nodes (`g4s.kube.small`, `g4s.kube.xsmall`) to
  save node resources, and an informational message is printed:
  "Logs collector not installed by default to save resource on small and
  xsmall standard nodes. If you wish to enable logs collector create the
  cluster with LogsCollectorEnable set to true"
- For all other node sizes, the value is left unset by default, so the
  API's own default applies.

Depends on civo/civogo#<PR_NUMBER_HERE> for the underlying
`LogsCollectorEnabled` field on `KubernetesClusterConfig` — needs to be
merged and released before this PR can build against a real civogo
version bump (currently uses a local `replace` only for testing, removed
before submission).

## Testing
Added unit tests in `utility/kubernetes_test.go` covering node-size
detection and the enable/disable resolution logic (explicit flag,
auto-disable on standard small/xsmall, default-deferred on other sizes,
and confirming non-standard tiers like performance/RAM/CPU-optimized are
not affected).